### PR TITLE
Updated plugin core to 1.5.3

### DIFF
--- a/lib/Config.py
+++ b/lib/Config.py
@@ -7,7 +7,7 @@ class Config:
 
     pluginName = 'Looplex_Lawtex_For_Sublime_Text'
 
-    pluginJar = 'looplex_lawtex_plugin-1.5.2.jar'
+    pluginJar = 'looplex_lawtex_plugin-1.5.3.jar'
 
     mainDataFolder = 'Looplex_Lawtex_Plugin'
     logsDataSubFolder = 'logs'


### PR DESCRIPTION
- Allows paths from import and attach comments to be qualified as absolute or relative (default) paths
- Added style comments to import style files
- Fixed issues regards importing style files via relative paths
- General code clean-up on API/ANTLR method calls